### PR TITLE
Allow periodic agents to evaluate if any new messages received

### DIFF
--- a/src/models/user.model/agent.model/index.js
+++ b/src/models/user.model/agent.model/index.js
@@ -179,7 +179,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
     return this.agentEvaluation
   }
 
-  if (this.minNewMessages && messageCount - this.lastActiveMessageCount < this.minNewMessages) {
+  if (userMessage && this.minNewMessages && messageCount - this.lastActiveMessageCount < this.minNewMessages) {
     logger.info('Not enough new messages for activation')
     this.agentEvaluation = { action: AgentMessageActions.OK, userContributionVisible: true }
     return this.agentEvaluation


### PR DESCRIPTION
Periodic agents should evaluate if any new messages received since last invocation, regardless of the minNewMessages attribute. This PR changes the logic to only consider minNewMessages if responding to an incoming message. This allows agents to respond if minNewMessages received OR a specified time period has gone by.