### PR TITLE
Process agent responses asynchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@socket.io/sticky": "^1.0.4",
     "agenda": "^5.0.0",
     "bcryptjs": "^2.4.3",
-    "chai": "^5.1.2",
     "change-case": "^5.4.4",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
@@ -74,6 +73,7 @@
   "devDependencies": {
     "audit-ci": "^7.1.0",
     "chai": "^5.1.2",
+    "chai-subset": "^1.6.0",
     "coveralls": "^3.0.7",
     "eslint": "^7.0.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/src/models/user.model/agent.model/agentTypes/civilityPerMessage.js
+++ b/src/models/user.model/agent.model/agentTypes/civilityPerMessage.js
@@ -45,15 +45,15 @@ module.exports = verify({
   async initialize() {
     return true
   },
-  async evaluate() {
-    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, this.userMessage)
+  async evaluate(userMessage) {
+    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, userMessage)
     const topic = this.thread.name
     const llmResponse = await getSinglePromptResponse(llm, template, { convHistory, topic })
 
     const action = llmResponse === 'OK' ? AgentMessageActions.OK : AgentMessageActions.REJECT
 
     this.agentEvaluation = {
-      userMessage: this.userMessage,
+      userMessage,
       action,
       agentContributionVisible: false,
       userContributionVisible: true,

--- a/src/models/user.model/agent.model/agentTypes/civilityPerMessagePerspectiveAPI.js
+++ b/src/models/user.model/agent.model/agentTypes/civilityPerMessagePerspectiveAPI.js
@@ -21,11 +21,11 @@ module.exports = verify({
   async initialize() {
     return true
   },
-  async evaluate() {
+  async evaluate(userMessage) {
     const googleClient = await google.discoverAPI(PERSPECTIVE_API_URL)
     const analyzeRequest = {
       comment: {
-        text: this.userMessage.body
+        text: userMessage.body
       },
       requestedAttributes: {
         TOXICITY: {},
@@ -52,11 +52,11 @@ module.exports = verify({
     const action = summaryScores.TOXICITY < TOXICITY_THRESHOLD ? AgentMessageActions.OK : AgentMessageActions.REJECT
 
     this.agentEvaluation = {
-      userMessage: this.userMessage,
+      userMessage,
       action,
       agentContributionVisible: false,
       userContributionVisible: true,
-      suggestion: `@${this.userMessage.user}: Please rephrase your comment to be more civil.`,
+      suggestion: `@${userMessage.user}: Please rephrase your comment to be more civil.`,
       contribution: undefined
     }
 

--- a/src/models/user.model/agent.model/agentTypes/playfulPerMessage.js
+++ b/src/models/user.model/agent.model/agentTypes/playfulPerMessage.js
@@ -37,22 +37,26 @@ module.exports = verify({
     return true
   },
   async evaluate() {
-    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, this.userMessage)
-    const topic = this.thread.name
-    const llmResponse = await getSinglePromptResponse(llm, template, { convHistory, topic })
-
-    this.agentEvaluation = {
+    return {
       userMessage: this.userMessage,
       action: AgentMessageActions.CONTRIBUTE,
-      agentContributionVisible: true,
       userContributionVisible: true,
-      suggestion: undefined,
-      contribution: llmResponse
+      suggestion: undefined
     }
-
-    return this.agentEvaluation
   },
   async isWithinTokenLimit(promptText) {
     return isWithinTokenLimit(promptText, this.tokenLimit)
+  },
+  async respond(userMessage) {
+    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, userMessage)
+    const topic = this.thread.name
+    const llmResponse = await getSinglePromptResponse(llm, template, { convHistory, topic })
+
+    const agentResponse = {
+      visible: true,
+      message: llmResponse
+    }
+
+    return [agentResponse]
   }
 })

--- a/src/models/user.model/agent.model/agentTypes/playfulPerMessage.js
+++ b/src/models/user.model/agent.model/agentTypes/playfulPerMessage.js
@@ -36,9 +36,9 @@ module.exports = verify({
   async initialize() {
     return true
   },
-  async evaluate() {
+  async evaluate(userMessage) {
     return {
-      userMessage: this.userMessage,
+      userMessage,
       action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined

--- a/src/models/user.model/agent.model/agentTypes/playfulPeriodic.js
+++ b/src/models/user.model/agent.model/agentTypes/playfulPeriodic.js
@@ -35,24 +35,29 @@ module.exports = verify({
     return true
   },
   async evaluate() {
-    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, this.userMessage)
-    const topic = this.thread.name
-    const llmResponse = await getSinglePromptResponse(llm, template, { convHistory, topic })
-
-    this.agentEvaluation = {
+    return {
       userMessage: this.userMessage,
       action: AgentMessageActions.CONTRIBUTE,
-      agentContributionVisible: true,
       userContributionVisible: true,
-      suggestion: undefined,
-      contribution: llmResponse
+      suggestion: undefined
     }
-
-    return this.agentEvaluation
   },
 
   // eslint-disable-next-line class-methods-use-this
   async isWithinTokenLimit(promptText) {
     return isWithinTokenLimit(promptText, this.tokenLimit)
+  },
+
+  async respond(userMessage) {
+    const convHistory = formatConvHistory(this.thread.messages, this.useNumLastMessages, userMessage)
+    const topic = this.thread.name
+    const llmResponse = await getSinglePromptResponse(llm, template, { convHistory, topic })
+
+    const agentResponse = {
+      visible: true,
+      message: llmResponse
+    }
+
+    return [agentResponse]
   }
 })

--- a/src/models/user.model/agent.model/agentTypes/playfulPeriodic.js
+++ b/src/models/user.model/agent.model/agentTypes/playfulPeriodic.js
@@ -34,9 +34,9 @@ module.exports = verify({
   async initialize() {
     return true
   },
-  async evaluate() {
+  async evaluate(userMessage) {
     return {
-      userMessage: this.userMessage,
+      userMessage,
       action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined

--- a/src/models/user.model/agent.model/agentTypes/reflection.js
+++ b/src/models/user.model/agent.model/agentTypes/reflection.js
@@ -50,8 +50,16 @@ module.exports = verify({
     return true
   },
   async evaluate() {
+    return {
+      userMessage: this.userMessage,
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+  },
+  async respond(userMessage) {
     const humanMsgs = this.thread.messages.filter((msg) => !msg.fromAgent)
-    const convHistory = formatConvHistory(humanMsgs, this.useNumLastMessages, this.userMessage)
+    const convHistory = formatConvHistory(humanMsgs, this.useNumLastMessages, userMessage)
 
     const summaryMessages = this.thread.messages.filter((msg) => msg.fromAgent && !msg.visible)
     const summaries = summaryMessages.map((message) => {
@@ -92,16 +100,12 @@ module.exports = verify({
 
     const llmResponse = await chain.invoke({ topic: this.thread.name, convHistory, summaries })
 
-    this.agentEvaluation = {
-      userMessage: this.userMessage,
-      action: AgentMessageActions.CONTRIBUTE,
-      agentContributionVisible: true,
-      userContributionVisible: true,
-      suggestion: undefined,
-      contribution: llmResponse
+    const agentResponse = {
+      visible: true,
+      message: llmResponse
     }
 
-    return this.agentEvaluation
+    return [agentResponse]
   },
   async isWithinTokenLimit(promptText) {
     return isWithinTokenLimit(promptText, this.tokenLimit)

--- a/src/models/user.model/agent.model/agentTypes/reflection.js
+++ b/src/models/user.model/agent.model/agentTypes/reflection.js
@@ -49,9 +49,9 @@ module.exports = verify({
   async initialize() {
     return true
   },
-  async evaluate() {
+  async evaluate(userMessage) {
     return {
-      userMessage: this.userMessage,
+      userMessage,
       action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined

--- a/src/models/user.model/agent.model/index.js
+++ b/src/models/user.model/agent.model/index.js
@@ -184,10 +184,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
     logger.info('Not enough new messages for activation')
     return { action: AgentMessageActions.OK, userContributionVisible: true }
   }
-
-  this.userMessage = userMessage
-
-  const agentEvaluation = validAgentEvaluation(await agentTypes[this.agentType].evaluate.call(this))
+  const agentEvaluation = validAgentEvaluation(await agentTypes[this.agentType].evaluate.call(this, userMessage))
   // Only reset timer if processing in response to a new message, otherwise let it continue periodic checking
   // do after LLM processing, since it may take some time
   if (userMessage && this.timerPeriod) await this.resetTimer()

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -164,17 +164,6 @@ const newMessageHandler = async (message, user) => {
     messages.push(sentMessage)
   }
 
-  if (config.enableAgents && thread.enableAgents) {
-    // then any agent messages
-    for (const agent of thread.agents) {
-      const agentMessage = await agent.respond()
-      if (agentMessage && agent.agentEvaluation.agentContributionVisible) {
-        agentMessage.count = thread.messages.length
-        messages.push(agentMessage)
-      }
-    }
-  }
-
   return messages
 }
 

--- a/src/types/agent.types.js
+++ b/src/types/agent.types.js
@@ -20,3 +20,9 @@ module.exports.AgentMessageActions = AgentMessageActions
  * @property {string} suggestion // back to submitter
  * @property {string} contribution // text to add from agent to the thread
  */
+
+/**
+ * @typedef {Object} AgentResponse
+ * @property {Boolean} visible
+ * @property {string} message
+ */

--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -1,10 +1,11 @@
+/* eslint-disable global-require */
 const http = require('http')
 const { availableParallelism } = require('node:os')
 const cluster = require('node:cluster')
-const { setupMaster, setupWorker } = require('@socket.io/sticky')
-const { createAdapter, setupPrimary } = require('@socket.io/cluster-adapter')
-const logger = require('../config/logger')
+const { setupMaster } = require('@socket.io/sticky')
+const { setupPrimary } = require('@socket.io/cluster-adapter')
 const config = require('../config/config')
+const socketIO = require('./socketIO')
 
 // Initialize an empty worker variable to take
 // the primary cluster instance for the rest of the
@@ -29,33 +30,17 @@ if (cluster.isMaster) {
   }
 } else {
   const httpServer = http.createServer()
-  const io = require('socket.io')(httpServer, {
-    cors: {
-      origin: '*'
-    },
-    connectionStateRecovery: {},
-    // set up the adapter on each worker thread
-    adapter: createAdapter()
-  })
-
-  io.adapter(createAdapter())
-  setupWorker(io)
-
+  socketIO.connect(httpServer)
+  const io = socketIO.connection()
   const registerMessageHandlers = require('./messageHandlers')
   const registerThreadHandlers = require('./threadHandlers')
+  io.addConnectionHandlers([registerMessageHandlers, registerThreadHandlers])
 
-  const onConnection = (socket) => {
-    logger.info('Socket connecting.')
-    registerMessageHandlers(io, socket)
-    registerThreadHandlers(io, socket)
-  }
-
-  io.on('connection', onConnection)
   // receive messages from the rest of the app and pass them on to every
   // child process' socket io instance
   process.on('message', function (message) {
     if (message.thread) {
-      io.in(message.thread).emit(message.event, message.message)
+      socketIO.emit(message.thread, message.event, message.message)
     }
   })
 }

--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -40,7 +40,7 @@ if (cluster.isMaster) {
   // child process' socket io instance
   process.on('message', function (message) {
     if (message.thread) {
-      socketIO.emit(message.thread, message.event, message.message)
+      io.emit(message.thread, message.event, message.message)
     }
   })
 }

--- a/src/websockets/socketIO.js
+++ b/src/websockets/socketIO.js
@@ -1,0 +1,56 @@
+const { createAdapter } = require('@socket.io/cluster-adapter')
+const { setupWorker } = require('@socket.io/sticky')
+const logger = require('../config/logger')
+
+let connection = null
+
+class SocketIO {
+  constructor() {
+    this.io = null
+  }
+
+  connect(server) {
+    // eslint-disable-next-line global-require
+    this.io = require('socket.io')(server, {
+      cors: {
+        origin: '*'
+      },
+      connectionStateRecovery: {},
+      // set up the adapter on each worker thread
+      adapter: createAdapter()
+    })
+    this.io.adapter(createAdapter())
+    setupWorker(this.io)
+  }
+
+  emit(channel, event, data) {
+    this.io.in(channel).emit(event, data)
+  }
+
+  addConnectionHandlers(handlers) {
+    this.io.on('connection', (socket) => {
+      logger.info('Socket connecting.')
+      for (const handler of handlers) {
+        handler(this.io, socket)
+      }
+    })
+  }
+
+  static init(server) {
+    if (!connection) {
+      connection = new SocketIO()
+      connection.connect(server)
+    }
+  }
+
+  static getConnection() {
+    if (connection) {
+      return connection
+    }
+  }
+}
+module.exports = {
+  SocketIO,
+  connect: SocketIO.init,
+  connection: SocketIO.getConnection
+}

--- a/tests/models/reflection.agent.test.mjs
+++ b/tests/models/reflection.agent.test.mjs
@@ -12,18 +12,25 @@ import agenda from 'agenda'
 import faker from 'faker'
 import mongoose from 'mongoose'
 import config from '../../src/config/config.js'
-import { expect } from 'chai'
+import socketIO from '../../src/websockets/socketIO.js'
+const sinon = await import('sinon')
+import { use, expect } from 'chai'
+import chaiSubset from 'chai-subset'
 const { Agent, Message, Thread, User, Topic } = await import('../../src/models/index.js')
 const { insertUsers } = await import('../fixtures/user.fixture.js')
 const { publicTopic } = await import('../fixtures/thread.fixture.js')
 const { insertTopics } = await import('../fixtures/topic.fixture.js')
 const { AgentMessageActions } = await import('../../src/types/agent.types.js')
-const formatConvHistory = await import('../../src/models/user.model/agent.model/helpers/formatConvHistory.js')
-const sinon = await import('sinon')
 
+use(chaiSubset)
 sinon.stub(agenda.prototype, 'start')
 sinon.stub(agenda.prototype, 'every')
 sinon.stub(agenda.prototype, 'cancel')
+const mockSocketInstance = {
+  emit: sinon.stub()
+}
+sinon.stub(socketIO, 'connection').returns(mockSocketInstance)
+const emitStub = mockSocketInstance.emit
 
 describe('reflection agent tests', () => {
   let agent
@@ -64,12 +71,41 @@ describe('reflection agent tests', () => {
     })
   }
 
-  async function checkNoOpEvaluation(evaluation) {
+  async function validateResponse(expectedMsgCount) {
+    await new Promise((resolve) => {
+      const intervalId = setInterval(() => {
+        if (emitStub.called) {
+          clearInterval(intervalId)
+          resolve()
+        }
+      }, 10) // Check every 10ms
+    })
+    expect(emitStub.calledOnce).to.be.true
+    const calledWithChannel = emitStub.firstCall.args[0]
+    const calledWithEventName = emitStub.firstCall.args[1]
+    const calledWithData = emitStub.firstCall.args[2]
+
+    expect(calledWithChannel).to.equal(thread._id.toString())
+    expect(calledWithEventName).to.equal('message:new')
+    expect(calledWithData).to.have.property('count', expectedMsgCount)
+    expect(calledWithData.body).to.not.be.undefined
+    // See agent response
+    console.log(calledWithData.body)
+    emitStub.resetHistory()
+    return calledWithData.body
+  }
+
+  async function checkNoResponseEvaluation(evaluation) {
     expect(evaluation).to.deep.equal({ action: AgentMessageActions.OK, userContributionVisible: true })
   }
 
-  async function checkNoOpResponse(response) {
-    expect(response).to.equal(undefined)
+  async function checkResponseEvaluation(evaluation, msg) {
+    expect(evaluation).to.deep.equal({
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined,
+      userMessage: msg
+    })
   }
 
   async function addMessageToThread(msg) {
@@ -106,6 +142,7 @@ describe('reflection agent tests', () => {
     user14 = await createUser('Smooth Crocodile')
 
     await insertUsers([user1, user2, user3, user4, user5, user6, user7])
+    await insertUsers([user8, user9, user10, user11, user12, user13, user14])
     await insertTopics([publicTopic])
 
     footballThread = {
@@ -135,8 +172,7 @@ describe('reflection agent tests', () => {
 
     const msg1 = await createMessage(user1, 'test 123')
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg1))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg1))
     await addMessageToThread(msg1)
 
     const msg2 = await createMessage(
@@ -144,8 +180,7 @@ describe('reflection agent tests', () => {
       'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg2))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg2))
     await addMessageToThread(msg2)
 
     const msg3 = await createMessage(
@@ -153,8 +188,7 @@ describe('reflection agent tests', () => {
       "Gladwell calls football a \"moral abomination,\" but I think the real abomination is how he picks one sport without contextualizing the ENTIRE community health risk posed by ALL sports. Ex: so far I haven't heard him mention the rate of concussions of girls heading 70 mph soccer balls. The rules in college and pro football have changed to better protect QBs and receivers. I think Gladwell put down his crumpet to watch football for 1 second and didn't like what he saw. He's an atrocious sports fan."
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg3))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg3))
     await addMessageToThread(msg3)
 
     const msg4 = await createMessage(
@@ -162,14 +196,12 @@ describe('reflection agent tests', () => {
       'Considering I\'ve read 4 of his books I\'m hesitant to say this, but I think Gladwell\'s commentaries on sports, and the "10,000 hour rule," have already unravelled. His "rule" has been utterly debunked, so you can imagine it doesn\'t apply to youth hockey as he tried to demonstrate in Outliers. From this video, he not only thinks boxing "disappeared," but he\'s also never heard of MMA apparently. Football and the lot have always been known as very dangerous sports.'
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg4))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg4))
     await addMessageToThread(msg4)
 
     const msg5 = await createMessage(user5, 'testing fooo')
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg5))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg5))
     await addMessageToThread(msg5)
 
     const msg6 = await createMessage(
@@ -177,42 +209,51 @@ describe('reflection agent tests', () => {
       "I'm excited to watch the Seattle Seahawks in the superbowl, not too concerned about the injuries."
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg6))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg6))
     await addMessageToThread(msg6)
 
     const msg7 = await createMessage(user7, 'asdjfkalsjdfkl')
     agent.thread = thread
-    const evaluation = await agent.evaluate(msg7)
-    console.log(evaluation.contribution)
-    expect(evaluation.contribution).to.not.be.undefined
+
+    await checkResponseEvaluation(await agent.evaluate(msg7), msg7)
     await addMessageToThread(msg7)
+
+    // We are currently including invisible messages in message count, so agent should add 2
+    const response = await validateResponse(9)
+    const expectedMessage = {
+      fromAgent: true,
+      visible: true,
+      body: response,
+      thread: thread._id,
+      pseudonym: agent.name,
+      pseudonymId: agent.pseudonyms[0]._id,
+      owner: agent._id
+    }
+    const agentMessages = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
+    expect(agentMessages.length).to.equal(1)
+    expect(agentMessages[0]).to.deep.include(expectedMessage)
 
     const msg8 = await createMessage(
       user8,
       'Guns are a part of our culture despite the frequent and horrific examples of their destruction. American Football will never fade because of its violent characteristics as long as we have guns.'
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg8))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg8))
     await addMessageToThread(msg8)
 
     const msg9 = await createMessage(user9, 'Football is forever American.')
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg9))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg9))
     await addMessageToThread(msg9)
 
     const msg10 = await createMessage(user10, "RuPaul's Drag Race is defining mainstream gay culture.")
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg10))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg10))
     await addMessageToThread(msg10)
 
     const msg11 = await createMessage(user11, 'Yellow color is associated with warmth.')
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg11))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg11))
     await addMessageToThread(msg11)
 
     const msg12 = await createMessage(
@@ -220,20 +261,32 @@ describe('reflection agent tests', () => {
       "Lots of professional sports cause long term injuries. Such as soccer, tennis, boxing ecetera. Isn't sport supposed to be healthy?"
     )
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg12))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg12))
     await addMessageToThread(msg12)
 
     const msg13 = await createMessage(user13, 'Football is amazing.')
     agent.thread = thread
-    await checkNoOpEvaluation(await agent.evaluate(msg13))
-    await checkNoOpResponse(await agent.respond())
+    await checkNoResponseEvaluation(await agent.evaluate(msg13))
     await addMessageToThread(msg13)
 
     const msg14 = await createMessage(user14, 'Yes.')
     agent.thread = thread
-    const evaluation2 = await agent.evaluate(msg14)
-    console.log(evaluation2.contribution)
-    expect(evaluation2.contribution).to.not.be.undefined
+
+    await checkResponseEvaluation(await agent.evaluate(msg14), msg14)
+    await addMessageToThread(msg14)
+
+    const response2 = await validateResponse(18)
+    const expectedMessage2 = {
+      fromAgent: true,
+      visible: true,
+      body: response2,
+      thread: thread._id,
+      pseudonym: agent.name,
+      pseudonymId: agent.pseudonyms[0]._id,
+      owner: agent._id
+    }
+    const agentMessages2 = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
+    expect(agentMessages2.length).to.equal(2)
+    expect(agentMessages2[1]).to.deep.include(expectedMessage2)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,6 +2797,11 @@ caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+  integrity sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==
+
 chai@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"


### PR DESCRIPTION
This PR schedules agent responses to occur asynchronously, in order to not block the last user message that triggered the response from appearing on the UI (or block the user from entering more messages). See individual commits for details.  This PR also solves the problem of agent messages not appearing on UI until a refresh when triggered by a timer (which did not previously broadcast a new message event to the client).

I suspect we will change this code again when we make it so that an agent can operate ONLY on a timer (i.e.only needs to respond, no need to evaluate an incoming message). But hopefully this works for now....