### PR TITLE
Fix failing tests

### DIFF
--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -15,11 +15,13 @@ const threadMessages = catchAsync(async (req, res) => {
 
 const vote = catchAsync(async (req, res) => {
   const message = await messageService.vote(req.params.messageId, req.body.direction, req.body.status, req.user);
-  worker.send({
-    thread: message.thread._id.toString(),
-    event: 'vote:new',
-    message,
-  });
+  if (worker) {
+    worker.send({
+      thread: message.thread._id.toString(),
+      event: 'vote:new',
+      message,
+    });
+  }
   res.status(httpStatus.OK).send(message);
 });
 

--- a/src/controllers/thread.controller.js
+++ b/src/controllers/thread.controller.js
@@ -5,21 +5,25 @@ const { worker } = require('../websockets/index');
 
 const createThread = catchAsync(async (req, res) => {
   const thread = await threadService.createThread(req.body, req.user);
-  worker.send({
-    thread: thread.topic._id.toString(),
-    event: 'thread:new',
-    message: thread,
-  });
+  if (worker) {
+    worker.send({
+      thread: thread.topic._id.toString(),
+      event: 'thread:new',
+      message: thread,
+    });
+  }
   res.status(httpStatus.CREATED).send(thread);
 });
 
 const updateThread = catchAsync(async (req, res) => {
   const thread = await threadService.updateThread(req.body, req.user);
-  worker.send({
-    thread: thread.topic._id.toString(),
-    event: 'thread:update',
-    message: thread,
-  });
+  if (worker) {
+    worker.send({
+      thread: thread.topic._id.toString(),
+      event: 'thread:update',
+      message: thread,
+    });
+  }
   res.status(httpStatus.OK).send(thread);
 });
 

--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -8,7 +8,7 @@ const errorConverter = (err, req, res, next) => {
   let error = err;
   if (!(error instanceof ApiError)) {
     const statusCode =
-      error.statusCode || error instanceof mongoose.Error ? httpStatus.BAD_REQUEST : httpStatus.INTERNAL_SERVER_ERROR;
+      error.statusCode || (error instanceof mongoose.Error ? httpStatus.BAD_REQUEST : httpStatus.INTERNAL_SERVER_ERROR);
     const message = error.message || httpStatus[statusCode];
     error = new ApiError(statusCode, message, false, err.stack);
   }

--- a/src/utils/WebsocketError.js
+++ b/src/utils/WebsocketError.js
@@ -3,6 +3,7 @@ class WebsocketError extends Error {
     super(error.message);
     this.originalError = error;
     this.data = data;
+    this.statusCode = error.statusCode;
 
     Error.captureStackTrace(this, this.constructor);
   }

--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -15,11 +15,14 @@ if (cluster.isMaster) {
   const httpServer = http.createServer();
   const numCPUs = availableParallelism();
   // create one worker per available core
-  for (let i = 0; i < numCPUs; i++) {
-    worker = cluster.fork({
-      PORT: 5555 + i,
-    });
+  if (config.env !== 'test') {
+    for (let i = 0; i < numCPUs; i++) {
+      worker = cluster.fork({
+        PORT: 5555 + i,
+      });
+    }
   }
+
   setupMaster(httpServer, {
     loadBalancingMethod: 'least-connection', // either "random", "round-robin" or "least-connection"
   });


### PR DESCRIPTION
Note: This PR is against main. I will backport the necessary fixes to our topic branches after merge. This fixes two issues that are described in the commit messages:
1) Clustering was causing jest to run once for every child process (that's why the integration tests were executing so many times). I could have kept clustering and pointed the child processes at the correct executable, but it made things really messy with Jest refusing to shut down and multiple clusters being started by every integration test. It ultimately didn't seem worth it to keep it enabled.
2) HTTP status codes getting lost on errors caused several tests to fail because they were catching legit bugs. I'm not sure it makes sense to throw a WebsocketError for everything the controllers do (even if not involving websockets), but this was the easiest fix for now. I have a task to work on error handling for our agents and may address there.