### PR TITLE
Jh/reflection intro response

### DIFF
--- a/src/models/user.model/agent.model/agentTypes/reflection.mjs
+++ b/src/models/user.model/agent.model/agentTypes/reflection.mjs
@@ -64,6 +64,8 @@ export default verify({
   useNumLastMessages: 7,
   minNewMessages: undefined,
   timerPeriod: '5 minutes',
+  introMessage: `Welcome to the conversation! I am your automated facilitator. You can ask me questions about the discussion topic or tips for healthy discourse by using @"Reflection Agent" in your message.
+    I will also chime in occasionally with my perspective on the discussion and some proposals for reaching consensus.`,
 
   async initialize() {
     return true

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -69,8 +69,9 @@ const createMessage = async (messageBody, user, thread) => {
 }
 
 const threadMessages = async (id) => {
-  const messages = await Message.find({ thread: id })
+  const messages = await Message.find({ thread: id, visible: true })
     .select('body owner upVotes downVotes pseudonym pseudonymId createdAt')
+    .where()
     .sort({ createdAt: 1 })
     .exec()
   return messages

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -58,7 +58,7 @@ const createThread = async (threadBody, user) => {
     await agent.save()
 
     // initialize to set up timer, etc.
-    await agent.initialize()
+    await agent.initialize(true)
 
     // depopulate thread to prevent circular clone
     agent.thread = thread._id

--- a/tests/models/agent.model.test.js
+++ b/tests/models/agent.model.test.js
@@ -49,6 +49,19 @@ jest.unstable_mockModule('../../src/models/user.model/agent.model/agentTypes/ind
       description: 'An agent that responds only periodically with no min messages',
       maxTokens: 2000,
       useNumLastMessages: 20,
+      minNewMessages: 2,
+      timerPeriod: '30 seconds',
+      priority: 200
+    },
+    periodicNoMin: {
+      initialize: mockInitialize,
+      respond: mockRespond,
+      evaluate: mockEvaluate,
+      isWithinTokenLimit: mockTokenLimit,
+      name: 'Test Periodic',
+      description: 'An agent that responds only periodically with no min messages',
+      maxTokens: 2000,
+      useNumLastMessages: 20,
       minNewMessages: undefined,
       timerPeriod: '30 seconds',
       priority: 200
@@ -186,6 +199,79 @@ let Agent
     expect(agent.lastActiveMessageCount).toEqual(2)
   })
 
+  test('should reset timer only on agent response to new message', async () => {
+    const agent = new Agent({
+      agentType: 'periodic',
+      thread
+    })
+    await agent.save()
+    await agent.initialize()
+    // ensure agenda was started
+    expect(agenda.start).toHaveBeenCalled()
+    expect(agenda.every).toHaveBeenCalled()
+    expect(mockInitialize).toHaveBeenCalled()
+    agent.thread = thread
+    const evaluation = await agent.evaluate(msg1)
+
+    expect(evaluation).toEqual({ action: AgentMessageActions.OK, userContributionVisible: true })
+
+    // timer should not be reset
+    expect(agenda.cancel).not.toHaveBeenCalled()
+
+    // User message is persisted after agent is called and gives the OK
+    await msg1.save()
+    thread.messages.push(msg1.toObject())
+    await thread.save()
+    await thread.populate('messages').execPopulate()
+
+    agent.thread = thread
+
+    const expectedEval = {
+      userMessage: msg2,
+      action: AgentMessageActions.CONTRIBUTE,
+      agentContributionVisible: true,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+
+    const expectedResponse = {
+      visible: true,
+      message: 'A response'
+    }
+
+    mockEvaluate.mockResolvedValue(expectedEval)
+    mockRespond.mockResolvedValue([expectedResponse])
+    const evaluation2 = await agent.evaluate(msg2)
+    expect(evaluation2).toEqual(expectedEval)
+
+    // verify async response
+    await waitFor(async () => {
+      const agentMessage = await Message.findOne({ fromAgent: true }).select('body count').exec()
+      if (agentMessage == null) throw Error('Agent message not found')
+      expect(agentMessage.body).toBe('A response')
+      expect(connection).toHaveBeenCalled()
+      const emitMock = connection.mock.results[0].value.emit
+      expect(emitMock).toHaveBeenCalledWith(
+        thread._id.toString(),
+        'message:new',
+        expect.objectContaining({ body: 'A response', count: 2 })
+      )
+    })
+
+    await msg2.save()
+    thread.messages.push(msg2.toObject())
+    await thread.save()
+    await thread.populate('messages').execPopulate()
+
+    // 2 user messages and one agent message processed at this point, but agent message should not count in calculation
+    agent.thread = thread
+    const evaluation3 = await agent.evaluate(msg3)
+    expect(evaluation3).toEqual({ action: AgentMessageActions.OK, userContributionVisible: true })
+    expect(agent.lastActiveMessageCount).toEqual(2)
+    // timer should be reset
+    expect(agenda.cancel).toHaveBeenCalled()
+  })
+
   test('should generate an AI response when any messages received since last periodic check', async () => {
     const agent = new Agent({
       agentType: 'periodic',
@@ -231,6 +317,30 @@ let Agent
         expect.objectContaining({ body: 'Another response', count: 2 })
       )
     })
+
+    // verify timer was not reset
+    expect(agenda.every).toHaveBeenCalledTimes(1)
+  })
+
+  test('should allow agent to evaluate when no messages received since last periodic check if minNewMessages undefined', async () => {
+    const agent = new Agent({
+      agentType: 'periodicNoMin',
+      thread
+    })
+    await agent.initialize()
+    expect(agenda.start).toHaveBeenCalled()
+    expect(agenda.every).toHaveBeenCalledWith(agent.timerPeriod, agent.agendaJobName, { agentId: agent._id })
+    expect(mockInitialize).toHaveBeenCalled()
+
+    mockEvaluate.mockResolvedValue({
+      action: AgentMessageActions.OK,
+      userContributionVisible: true,
+      userMessage: null,
+      suggestion: undefined
+    })
+    await agent.evaluate()
+    expect(mockEvaluate).toHaveBeenCalled()
+    expect(mockRespond).not.toHaveBeenCalled()
 
     // verify timer was not reset
     expect(agenda.every).toHaveBeenCalledTimes(1)

--- a/tests/models/agentTypes/reflection.agent.test.js
+++ b/tests/models/agentTypes/reflection.agent.test.js
@@ -72,9 +72,9 @@ setupIntTest()
     })
   }
 
-  async function validateResponse(expectedMsgCount) {
+  async function validateResponse(expectedMsgCount, expectedVisibleAgentMsgCount) {
     // eslint-disable-next-line no-return-await
-    return await waitFor(async () => {
+    const agentMsg = await waitFor(async () => {
       expect(connection).toHaveBeenCalled()
       const emitMock = connection.mock.results[0].value.emit
       expect(emitMock).toHaveBeenCalledWith(
@@ -87,10 +87,22 @@ setupIntTest()
       console.log(response.body)
       return response.body
     }, 60000)
+    const expectedMessage = {
+      fromAgent: true,
+      visible: true,
+      body: agentMsg,
+      thread: thread._id,
+      pseudonym: agent.name,
+      pseudonymId: agent.pseudonyms[0]._id,
+      owner: agent._id
+    }
+    const agentMessages = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
+    expect(agentMessages.length).toBe(expectedVisibleAgentMsgCount)
+    expect(agentMessages).toContainEqual(expect.objectContaining(expectedMessage))
   }
 
-  async function checkNoResponseEvaluation(evaluation) {
-    expect(evaluation).toEqual({ action: AgentMessageActions.OK, userContributionVisible: true })
+  async function checkOkResponseEvaluation(evaluation) {
+    expect(evaluation).toEqual(expect.objectContaining({ action: AgentMessageActions.OK, userContributionVisible: true }))
   }
 
   async function checkResponseEvaluation(evaluation, msg) {
@@ -162,7 +174,7 @@ setupIntTest()
 
     const msg1 = await createMessage(user1, 'test 123')
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg1))
+    await checkOkResponseEvaluation(await agent.evaluate(msg1))
     await addMessageToThread(msg1)
 
     const msg2 = await createMessage(
@@ -170,7 +182,7 @@ setupIntTest()
       'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg2))
+    await checkOkResponseEvaluation(await agent.evaluate(msg2))
     await addMessageToThread(msg2)
 
     const msg3 = await createMessage(
@@ -178,7 +190,7 @@ setupIntTest()
       "Gladwell calls football a \"moral abomination,\" but I think the real abomination is how he picks one sport without contextualizing the ENTIRE community health risk posed by ALL sports. Ex: so far I haven't heard him mention the rate of concussions of girls heading 70 mph soccer balls. The rules in college and pro football have changed to better protect QBs and receivers. I think Gladwell put down his crumpet to watch football for 1 second and didn't like what he saw. He's an atrocious sports fan."
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg3))
+    await checkOkResponseEvaluation(await agent.evaluate(msg3))
     await addMessageToThread(msg3)
 
     const msg4 = await createMessage(
@@ -186,12 +198,12 @@ setupIntTest()
       'Considering I\'ve read 4 of his books I\'m hesitant to say this, but I think Gladwell\'s commentaries on sports, and the "10,000 hour rule," have already unravelled. His "rule" has been utterly debunked, so you can imagine it doesn\'t apply to youth hockey as he tried to demonstrate in Outliers. From this video, he not only thinks boxing "disappeared," but he\'s also never heard of MMA apparently. Football and the lot have always been known as very dangerous sports.'
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg4))
+    await checkOkResponseEvaluation(await agent.evaluate(msg4))
     await addMessageToThread(msg4)
 
     const msg5 = await createMessage(user5, 'testing fooo')
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg5))
+    await checkOkResponseEvaluation(await agent.evaluate(msg5))
     await addMessageToThread(msg5)
 
     const msg6 = await createMessage(
@@ -199,7 +211,7 @@ setupIntTest()
       "I'm excited to watch the Seattle Seahawks in the superbowl, not too concerned about the injuries."
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg6))
+    await checkOkResponseEvaluation(await agent.evaluate(msg6))
     await addMessageToThread(msg6)
 
     const msg7 = await createMessage(user7, 'asdjfkalsjdfkl')
@@ -209,20 +221,7 @@ setupIntTest()
     await addMessageToThread(msg7)
 
     // We are currently including invisible messages in message count, so agent should add 2
-    const response = await validateResponse(9)
-
-    const expectedMessage = {
-      fromAgent: true,
-      visible: true,
-      body: response,
-      thread: thread._id,
-      pseudonym: agent.name,
-      pseudonymId: agent.pseudonyms[0]._id,
-      owner: agent._id
-    }
-    const agentMessages = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
-    expect(agentMessages.length).toBe(1)
-    expect(agentMessages[0]).toEqual(expect.objectContaining(expectedMessage))
+    await validateResponse(9, 1)
 
     jest.clearAllMocks()
 
@@ -231,22 +230,22 @@ setupIntTest()
       'Guns are a part of our culture despite the frequent and horrific examples of their destruction. American Football will never fade because of its violent characteristics as long as we have guns.'
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg8))
+    await checkOkResponseEvaluation(await agent.evaluate(msg8))
     await addMessageToThread(msg8)
 
     const msg9 = await createMessage(user9, 'Football is forever American.')
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg9))
+    await checkOkResponseEvaluation(await agent.evaluate(msg9))
     await addMessageToThread(msg9)
 
     const msg10 = await createMessage(user10, "RuPaul's Drag Race is defining mainstream gay culture.")
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg10))
+    await checkOkResponseEvaluation(await agent.evaluate(msg10))
     await addMessageToThread(msg10)
 
     const msg11 = await createMessage(user11, 'Yellow color is associated with warmth.')
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg11))
+    await checkOkResponseEvaluation(await agent.evaluate(msg11))
     await addMessageToThread(msg11)
 
     const msg12 = await createMessage(
@@ -254,12 +253,12 @@ setupIntTest()
       "Lots of professional sports cause long term injuries. Such as soccer, tennis, boxing ecetera. Isn't sport supposed to be healthy?"
     )
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg12))
+    await checkOkResponseEvaluation(await agent.evaluate(msg12))
     await addMessageToThread(msg12)
 
     const msg13 = await createMessage(user13, 'Football is amazing.')
     agent.thread = thread
-    await checkNoResponseEvaluation(await agent.evaluate(msg13))
+    await checkOkResponseEvaluation(await agent.evaluate(msg13))
     await addMessageToThread(msg13)
 
     const msg14 = await createMessage(user14, 'Yes.')
@@ -268,18 +267,164 @@ setupIntTest()
     await checkResponseEvaluation(await agent.evaluate(msg14), msg14)
     await addMessageToThread(msg14)
 
-    const response2 = await validateResponse(18)
-    const expectedMessage2 = {
-      fromAgent: true,
-      visible: true,
-      body: response2,
-      thread: thread._id,
-      pseudonym: agent.name,
-      pseudonymId: agent.pseudonyms[0]._id,
-      owner: agent._id
-    }
-    const agentMessages2 = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
-    expect(agentMessages2.length).toBe(2)
-    expect(agentMessages2[1]).toEqual(expect.objectContaining(expectedMessage2))
+    await validateResponse(18, 2)
+  })
+
+  it('should respond when addressed by a participant about the discussion topic while keeping summarization count', async () => {
+    await agent.initialize()
+
+    const msg1 = await createMessage(user1, 'test 123')
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg1))
+    await addMessageToThread(msg1)
+
+    const msg2 = await createMessage(
+      user2,
+      'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg2))
+    await addMessageToThread(msg2)
+
+    const msg3 = await createMessage(
+      user3,
+      "Gladwell calls football a \"moral abomination,\" but I think the real abomination is how he picks one sport without contextualizing the ENTIRE community health risk posed by ALL sports. Ex: so far I haven't heard him mention the rate of concussions of girls heading 70 mph soccer balls. The rules in college and pro football have changed to better protect QBs and receivers. I think Gladwell put down his crumpet to watch football for 1 second and didn't like what he saw. He's an atrocious sports fan."
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg3))
+    await addMessageToThread(msg3)
+
+    const msg4 = await createMessage(
+      user4,
+      'Considering I\'ve read 4 of his books I\'m hesitant to say this, but I think Gladwell\'s commentaries on sports, and the "10,000 hour rule," have already unravelled. His "rule" has been utterly debunked, so you can imagine it doesn\'t apply to youth hockey as he tried to demonstrate in Outliers. From this video, he not only thinks boxing "disappeared," but he\'s also never heard of MMA apparently. Football and the lot have always been known as very dangerous sports.'
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg4))
+    await addMessageToThread(msg4)
+
+    // manual verification - response to topic question
+    const msg5 = await createMessage(
+      user5,
+      'Hey @"Reflection Agent", I heard that over one hundred football players are diagnosed with CTE every year. Is that true?'
+    )
+    agent.thread = thread
+    await checkResponseEvaluation(await agent.evaluate(msg5), msg5)
+    await addMessageToThread(msg5)
+
+    await validateResponse(6, 1)
+    jest.clearAllMocks()
+
+    const msg6 = await createMessage(
+      user6,
+      "You guys should all toughen up. Football is the great American sport and if you can't handle injury, get out of the game"
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg6))
+    await addMessageToThread(msg6)
+
+    // This is message 7, should trigger summarization
+    const msg7 = await createMessage(user7, 'asdjfkalsjdfkl')
+    agent.thread = thread
+    await checkResponseEvaluation(await agent.evaluate(msg7), msg7)
+    await addMessageToThread(msg7)
+
+    await validateResponse(10, 2)
+    jest.clearAllMocks()
+
+    // This message should not
+    const msg8 = await createMessage(
+      user8,
+      'Guns are a part of our culture despite the frequent and horrific examples of their destruction. American Football will never fade because of its violent characteristics as long as we have guns.'
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg8))
+    await addMessageToThread(msg8)
+  })
+
+  it('should summarize on the 8th message if 7th is a direct question', async () => {
+    await agent.initialize()
+
+    const msg1 = await createMessage(user1, 'test 123')
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg1))
+    await addMessageToThread(msg1)
+
+    const msg2 = await createMessage(
+      user2,
+      'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg2))
+    await addMessageToThread(msg2)
+
+    const msg3 = await createMessage(
+      user3,
+      "Gladwell calls football a \"moral abomination,\" but I think the real abomination is how he picks one sport without contextualizing the ENTIRE community health risk posed by ALL sports. Ex: so far I haven't heard him mention the rate of concussions of girls heading 70 mph soccer balls. The rules in college and pro football have changed to better protect QBs and receivers. I think Gladwell put down his crumpet to watch football for 1 second and didn't like what he saw. He's an atrocious sports fan."
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg3))
+    await addMessageToThread(msg3)
+
+    const msg4 = await createMessage(
+      user4,
+      'Considering I\'ve read 4 of his books I\'m hesitant to say this, but I think Gladwell\'s commentaries on sports, and the "10,000 hour rule," have already unravelled. His "rule" has been utterly debunked, so you can imagine it doesn\'t apply to youth hockey as he tried to demonstrate in Outliers. From this video, he not only thinks boxing "disappeared," but he\'s also never heard of MMA apparently. Football and the lot have always been known as very dangerous sports.'
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg4))
+    await addMessageToThread(msg4)
+
+    const msg5 = await createMessage(user5, 'asdjfkalsjdfkl')
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg5))
+    await addMessageToThread(msg5)
+
+    const msg6 = await createMessage(
+      user6,
+      "You guys should all toughen up. Football is the great American sport and if you can't handle injury, get out of the game"
+    )
+    agent.thread = thread
+    await checkOkResponseEvaluation(await agent.evaluate(msg6))
+    await addMessageToThread(msg6)
+
+    // manual verification - response to off-topic question
+    const msg7 = await createMessage(user7, '@"Reflection Agent" what is your favorite beer?')
+    await checkResponseEvaluation(await agent.evaluate(msg7), msg7)
+    await addMessageToThread(msg7)
+    await validateResponse(8, 1)
+    jest.clearAllMocks()
+
+    // This message should trigger summarization
+    const msg8 = await createMessage(
+      user8,
+      'Guns are a part of our culture despite the frequent and horrific examples of their destruction. American Football will never fade because of its violent characteristics as long as we have guns.'
+    )
+    agent.thread = thread
+    await checkResponseEvaluation(await agent.evaluate(msg8), msg8)
+    await addMessageToThread(msg8)
+    await validateResponse(11, 2)
+    jest.clearAllMocks()
+
+    // manual verification - response to message about civil discourse
+    const msg9 = await createMessage(
+      user9,
+      'Hey @"Reflection Agent", what is the appropriate way to respond to @Happy Ant\'s message? It is really offensive.'
+    )
+    await checkResponseEvaluation(await agent.evaluate(msg9), msg9)
+    await addMessageToThread(msg9)
+    await validateResponse(13, 3)
+  })
+
+  it('should respond on perodic invocation if at least one new message', async () => {
+    const msg2 = await createMessage(
+      user2,
+      'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
+    )
+    agent.thread = thread
+    await addMessageToThread(msg2)
+    await checkResponseEvaluation(await agent.evaluate(), null)
+    await validateResponse(3, 1)
+
+    // no response because no new messages
+    await checkOkResponseEvaluation(await agent.evaluate())
   })
 })

--- a/tests/models/agentTypes/reflection.agent.test.js
+++ b/tests/models/agentTypes/reflection.agent.test.js
@@ -161,12 +161,30 @@ setupIntTest()
       agentType: 'reflection',
       thread: thread._id
     })
+    agent.thread = thread
     await agent.save()
   })
 
   afterEach(async () => {
     jest.clearAllMocks()
     jest.resetModules()
+  })
+
+  it('should generate an intro message', async () => {
+    await agent.initialize(true)
+    const expectedMessage = {
+      fromAgent: true,
+      visible: true,
+      body: agent.introMessage,
+      thread: thread._id,
+      pseudonym: agent.name,
+      pseudonymId: agent.pseudonyms[0]._id,
+      owner: agent._id
+    }
+    await thread.populate('messages').execPopulate()
+    const agentMessages = thread.messages.filter((msg) => msg.fromAgent && msg.visible)
+    expect(agentMessages.length).toBe(1)
+    expect(agentMessages).toContainEqual(expect.objectContaining(expectedMessage))
   })
 
   it('should generate an AI response when min messages received', async () => {


### PR DESCRIPTION
Adds @ ability and intro message to Reflection agent (and infrastructure for any agent to have intro messages). Also fixes an issue where periodic processing on the primary node was failing to send agent response on websocket.

Lastly, filtered out invisible messages on load to keep reflection agent's invisible summarization messages from showing up if we have to restart or user switches threads during play testing. I started on updating message counts to exclude invisible messages but ran out of time, so those are still off.