### PR TITLE
Fix duplicate agent responses

### DIFF
--- a/src/agenda.js
+++ b/src/agenda.js
@@ -1,6 +1,19 @@
 const Agenda = require('agenda')
 const config = require('./config/config')
+const logger = require('./config/logger')
 
 const agenda = new Agenda({ db: { address: config.mongoose.url } })
+
+agenda.on('fail', (err, job) => {
+  logger.error(`[AGENDA] Job ${job.attrs.name} failed:`, {
+    error: err.message,
+    jobData: job.attrs,
+    pid: process.pid
+  })
+})
+
+agenda.on('error', (error) => {
+  logger.error('[AGENDA] Global error:', error)
+})
 
 module.exports = agenda

--- a/src/models/user.model/agent.model/agentTypes/reflection.mjs
+++ b/src/models/user.model/agent.model/agentTypes/reflection.mjs
@@ -85,8 +85,8 @@ export default verify({
           ? this.thread.messages.filter((msg) => !msg.fromAgent).length
           : this.thread.messages.slice(lastInvisibleIndex).filter((msg) => !msg.fromAgent).length
 
-      if (!userMessage && countSinceSummary > 0) {
-        // periodic invocation - there has been at least one new message
+      if (!userMessage && countSinceSummary > 1) {
+        // periodic invocation - there have been at least two new messages
         action = AgentMessageActions.CONTRIBUTE
       } else if (userMessage && countSinceSummary + 1 >= minMessagesForSummary) {
         action = AgentMessageActions.CONTRIBUTE

--- a/tests/models/agentTypes/reflection.agent.test.js
+++ b/tests/models/agentTypes/reflection.agent.test.js
@@ -432,15 +432,23 @@ setupIntTest()
     await validateResponse(13, 3)
   })
 
-  it('should respond on perodic invocation if at least one new message', async () => {
+  it('should respond on perodic invocation if at least two new messages', async () => {
+    const msg1 = await createMessage(user1, 'test 123')
+    agent.thread = thread
+    await addMessageToThread(msg1)
+
+    // doesn't respond on first message
+    await checkOkResponseEvaluation(await agent.evaluate())
+
     const msg2 = await createMessage(
       user2,
       'The monetary incentives of professional football will continue to attract players for a long time, particularly from low income populations.'
     )
     agent.thread = thread
     await addMessageToThread(msg2)
+    // responds on second
     await checkResponseEvaluation(await agent.evaluate(), null)
-    await validateResponse(3, 1)
+    await validateResponse(4, 1)
 
     // no response because no new messages
     await checkOkResponseEvaluation(await agent.evaluate())


### PR DESCRIPTION
The reflection agent was double responding because immediately after processing a message (either b/c it reached the min threshold or b/c it was responding to an @), we rescheduled the job in agenda and it immediately executed. 

I configured agenda to skip immediate execution, but also decided to remove the timer reset, because I don't want an @ message to reset the timer. Ultimately, I think agents should still process at the same periodic interval without resetting on message receipt for greater flexibility.