### PR TITLE
Support pausing discussion and distinct visualizations of agent messages

### DIFF
--- a/src/models/user.model/agent.model/agentTypes/reflection.mjs
+++ b/src/models/user.model/agent.model/agentTypes/reflection.mjs
@@ -106,7 +106,7 @@ export default verify({
   },
   async respond(userMessage) {
     let llmResponse
-    let pause = true
+    let pause = 0
     const humanMsgs = this.thread.messages.filter((msg) => !msg.fromAgent)
     const convHistory = formatConvHistory(humanMsgs, this.useNumLastMessages)
 
@@ -121,8 +121,8 @@ export default verify({
         topic: this.thread.name,
         question: `${userMessage.user}: ${userMessage.body}`
       })
-      pause = false
     } else {
+      pause = 30
       const summarizationPrompt = PromptTemplate.fromTemplate(summarizationTemplate)
       const summarizationChain = summarizationPrompt.pipe(llm).pipe(new StringOutputParser())
       const consensusPrompt = PromptTemplate.fromTemplate(consensusTemplate)

--- a/src/models/user.model/agent.model/agentTypes/reflection.mjs
+++ b/src/models/user.model/agent.model/agentTypes/reflection.mjs
@@ -106,6 +106,7 @@ export default verify({
   },
   async respond(userMessage) {
     let llmResponse
+    let pause = true
     const humanMsgs = this.thread.messages.filter((msg) => !msg.fromAgent)
     const convHistory = formatConvHistory(humanMsgs, this.useNumLastMessages)
 
@@ -120,6 +121,7 @@ export default verify({
         topic: this.thread.name,
         question: `${userMessage.user}: ${userMessage.body}`
       })
+      pause = false
     } else {
       const summarizationPrompt = PromptTemplate.fromTemplate(summarizationTemplate)
       const summarizationChain = summarizationPrompt.pipe(llm).pipe(new StringOutputParser())
@@ -161,7 +163,8 @@ export default verify({
 
     const agentResponse = {
       visible: true,
-      message: llmResponse
+      message: llmResponse,
+      pause
     }
 
     return [agentResponse]

--- a/src/models/user.model/agent.model/index.mjs
+++ b/src/models/user.model/agent.model/index.mjs
@@ -233,7 +233,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
                   event: 'message:new',
                   message: {
                     ...agentMessage.toJSON(),
-                    pause: !!response.pause,
+                    pause: response.pause,
                     count: agentMessage.count
                   }
                 })
@@ -241,7 +241,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
                 const io = socketIO.connection()
                 io.emit(agentMessage.thread._id.toString(), 'message:new', {
                   ...agentMessage.toJSON(),
-                  pause: !!response.pause,
+                  pause: response.pause,
                   count: agentMessage.count
                 })
               }

--- a/src/models/user.model/agent.model/index.mjs
+++ b/src/models/user.model/agent.model/index.mjs
@@ -171,7 +171,7 @@ agentSchema.method('initialize', async function (newAgent = false) {
       owner: this._id
     })
 
-    agentMessage.save()
+    await agentMessage.save()
     this.thread.messages.push(agentMessage.toObject())
     await this.thread.save()
   }
@@ -223,7 +223,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
                 owner: this._id
               })
 
-              agentMessage.save()
+              await agentMessage.save()
               this.thread.messages.push(agentMessage.toObject())
               await this.thread.save()
               agentMessage.count = this.thread.messages.length

--- a/src/models/user.model/agent.model/index.mjs
+++ b/src/models/user.model/agent.model/index.mjs
@@ -233,6 +233,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
                   event: 'message:new',
                   message: {
                     ...agentMessage.toJSON(),
+                    pause: !!response.pause,
                     count: agentMessage.count
                   }
                 })
@@ -240,6 +241,7 @@ agentSchema.method('evaluate', async function (userMessage = null) {
                 const io = socketIO.connection()
                 io.emit(agentMessage.thread._id.toString(), 'message:new', {
                   ...agentMessage.toJSON(),
+                  pause: !!response.pause,
                   count: agentMessage.count
                 })
               }

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -70,8 +70,7 @@ const createMessage = async (messageBody, user, thread) => {
 
 const threadMessages = async (id) => {
   const messages = await Message.find({ thread: id, visible: true })
-    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt')
-    .where()
+    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt fromAgent')
     .sort({ createdAt: 1 })
     .exec()
   return messages

--- a/tests/models/agent.model.test.js
+++ b/tests/models/agent.model.test.js
@@ -273,7 +273,7 @@ let Agent
       expect(emitMock).toHaveBeenCalledWith(
         thread._id.toString(),
         'message:new',
-        expect.objectContaining({ body: 'Another response', count: 2 })
+        expect.objectContaining({ body: 'Another response', count: 2, pause: undefined })
       )
     })
   })

--- a/tests/models/agentTypes/reflection.agent.test.js
+++ b/tests/models/agentTypes/reflection.agent.test.js
@@ -69,7 +69,7 @@ setupIntTest()
     }
   }
 
-  async function validateResponse(expectedMsgCount, expectedVisibleAgentMsgCount) {
+  async function validateResponse(expectedMsgCount, expectedVisibleAgentMsgCount, expectedPause = true) {
     // eslint-disable-next-line no-return-await
     const agentMsg = await waitFor(async () => {
       expect(connection).toHaveBeenCalled()
@@ -77,7 +77,7 @@ setupIntTest()
       expect(emitMock).toHaveBeenCalledWith(
         thread._id.toString(),
         'message:new',
-        expect.objectContaining({ count: expectedMsgCount })
+        expect.objectContaining({ count: expectedMsgCount, pause: expectedPause })
       )
       const response = emitMock.mock.calls[0][2]
       // eslint-disable-next-line no-console
@@ -334,7 +334,7 @@ setupIntTest()
     await checkResponseEvaluation(await agent.evaluate(msg5), msg5)
     await addMessageToThread(msg5, user5)
 
-    await validateResponse(6, 1)
+    await validateResponse(6, 1, false)
     jest.clearAllMocks()
 
     const msg6 = await createMessage(
@@ -413,7 +413,7 @@ setupIntTest()
     const msg7 = await createMessage(user7, '@"Reflection Agent" what is your favorite beer?')
     await checkResponseEvaluation(await agent.evaluate(msg7), msg7)
     await addMessageToThread(msg7, user7)
-    await validateResponse(8, 1)
+    await validateResponse(8, 1, false)
     jest.clearAllMocks()
 
     // This message should trigger summarization
@@ -434,7 +434,7 @@ setupIntTest()
     )
     await checkResponseEvaluation(await agent.evaluate(msg9), msg9)
     await addMessageToThread(msg9, user9)
-    await validateResponse(13, 3)
+    await validateResponse(13, 3, false)
   })
 
   it('should respond on perodic invocation if at least two new messages', async () => {

--- a/tests/models/agentTypes/reflection.agent.test.js
+++ b/tests/models/agentTypes/reflection.agent.test.js
@@ -69,7 +69,7 @@ setupIntTest()
     }
   }
 
-  async function validateResponse(expectedMsgCount, expectedVisibleAgentMsgCount, expectedPause = true) {
+  async function validateResponse(expectedMsgCount, expectedVisibleAgentMsgCount, expectedPause = 30) {
     // eslint-disable-next-line no-return-await
     const agentMsg = await waitFor(async () => {
       expect(connection).toHaveBeenCalled()
@@ -334,7 +334,7 @@ setupIntTest()
     await checkResponseEvaluation(await agent.evaluate(msg5), msg5)
     await addMessageToThread(msg5, user5)
 
-    await validateResponse(6, 1, false)
+    await validateResponse(6, 1, 0)
     jest.clearAllMocks()
 
     const msg6 = await createMessage(
@@ -413,7 +413,7 @@ setupIntTest()
     const msg7 = await createMessage(user7, '@"Reflection Agent" what is your favorite beer?')
     await checkResponseEvaluation(await agent.evaluate(msg7), msg7)
     await addMessageToThread(msg7, user7)
-    await validateResponse(8, 1, false)
+    await validateResponse(8, 1, 0)
     jest.clearAllMocks()
 
     // This message should trigger summarization
@@ -434,7 +434,7 @@ setupIntTest()
     )
     await checkResponseEvaluation(await agent.evaluate(msg9), msg9)
     await addMessageToThread(msg9, user9)
-    await validateResponse(13, 3, false)
+    await validateResponse(13, 3, 0)
   })
 
   it('should respond on perodic invocation if at least two new messages', async () => {


### PR DESCRIPTION
Ensure the fromAgent property is present in messages retrieved by client. Add optional "pause" property to agent response to indicate discussion should be paused while participants read the response.