### PR TITLE
Adds Env Var for disabling public channel creation.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ MAX_MESSAGE_LENGTH=2000
 # App functionality toggles
 NYMSPACE_ENABLE_AGENTS=true
 NYMSPACE_ENABLE_POLLS=true
+NYMSPACE_ENABLE_PUBLIC_CHANNEL_CREATION=true
 
 # Optional API keys that are needed for some LLM functionality
 OPENAI_API_KEY=

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -14,6 +14,7 @@ const envVarsSchema = Joi.object()
     MONGODB_DEBUG: Joi.boolean().description('Enable mongoose debugging'),
     NYMSPACE_ENABLE_AGENTS: Joi.boolean().default(false).description('Enable agent support'),
     NYMSPACE_ENABLE_POLLS: Joi.boolean().default(false).description('Enable poll support'),
+    NYMSPACE_ENABLE_PUBLIC_CHANNEL_CREATION: Joi.boolean().default(false).description('Enable channel creation'),
     JWT_SECRET: Joi.string().required().description('JWT secret key'),
     JWT_ACCESS_EXPIRATION_MINUTES: Joi.number().default(30).description('minutes after which access tokens expire'),
     JWT_REFRESH_EXPIRATION_DAYS: Joi.number().default(30).description('days after which refresh tokens expire'),
@@ -83,6 +84,8 @@ module.exports = {
   maxMessageLength: envVars.MAX_MESSAGE_LENGTH,
   enablePolls: envVars.NYMSPACE_ENABLE_POLLS,
   enableAgents: envVars.NYMSPACE_ENABLE_AGENTS,
+  enablePublicChannelCreation: envVars.NYMSPACE_ENABLE_PUBLIC_CHANNEL_CREATION,
+
   llms: {
     basePath: envVars.LANGCHAIN_API_BASE_PATH,
     openAI: {

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -6,6 +6,7 @@ const Token = require('../models/token.model')
 const ApiError = require('../utils/ApiError')
 const updateDocument = require('../utils/updateDocument')
 const User = require('../models/user.model/user.model')
+const config = require('../config/config')
 
 /**
  * Query topics and add sorting properties
@@ -91,11 +92,12 @@ const createTopic = async (topicBody, user) => {
   if (topicBody.private) {
     passcode = await randomPasscode(1000000, 9999999)
   }
+
   const topic = await Topic.create({
     name: topicBody.name,
     votingAllowed: topicBody.votingAllowed,
     threadCreationAllowed: topicBody.threadCreationAllowed,
-    private: topicBody.private,
+    private: config.enablePublicChannelCreation ? topicBody.private : true,
     archivable: topicBody.archivable,
     archiveEmail: topicBody.archiveEmail,
     passcode,


### PR DESCRIPTION
This change introduces an environment variable which can be set to disable the ability to create public channels. This environment variable only impacts the API's ability to create public channels. A separate environment variable needs to also be set in the client in order to disable the associated UI.