### PR TITLE
Fixes websocket clustering port collision bug.

### DIFF
--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -19,7 +19,7 @@ if (cluster.isMaster) {
   const numCPUs = availableParallelism()
   // create one worker per available core
   if (config.env !== 'test') {
-    for (let i = 0; i < numCPUs; i += 1) {
+    for (let i = 1; i < numCPUs; i += 1) {
       worker = cluster.fork({
         PORT: config.websocketBasePort + i
       })
@@ -31,7 +31,7 @@ if (cluster.isMaster) {
   })
   setupPrimary()
   if (config.env !== 'test') {
-    httpServer.listen(5555)
+    httpServer.listen(config.websocketBasePort)
   }
 } else {
   const httpServer = http.createServer()


### PR DESCRIPTION
The server was starting with an EADDRINUSE error because the primary process and the first worker process were both trying to start on that port.

