### PR TITLE
Hiddenmessages

### DIFF
--- a/src/config/roles.js
+++ b/src/config/roles.js
@@ -30,8 +30,8 @@ const allRoles = {
     'getPollResponses',
     'getPollResponseCounts',
 
-    // hit the button roles
-    'revealHitTheButtonHiddenMessages'
+    // hidden message mode roles
+    'revealHiddenMessageModeMessages'
   ],
   admin: ['getUsers', 'manageUsers']
 }

--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -9,12 +9,14 @@ const createMessage = catchAsync(async (req, res) => {
 })
 
 const threadMessages = catchAsync(async (req, res) => {
-  const messages = await messageService.threadMessages(req.params.threadId, req.user.id)
+  const userId = req.user ? req.user.id : null
+  const messages = await messageService.threadMessages(req.params.threadId, userId)
   res.status(httpStatus.OK).send(messages)
 })
 
 const messageReplies = catchAsync(async (req, res) => {
-  const replies = await messageService.getMessageReplies(req.params.messageId, req.user.id)
+  const userId = req.user ? req.user.id : null
+  const replies = await messageService.getMessageReplies(req.params.messageId, userId)
   res.status(httpStatus.OK).send(replies)
 })
 

--- a/src/controllers/thread.controller.js
+++ b/src/controllers/thread.controller.js
@@ -27,8 +27,8 @@ const updateThread = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send(thread)
 })
 
-const revealHitTheButtonHiddenMessages = catchAsync(async (req, res) => {
-  const thread = await threadService.revealHitTheButtonHiddenMessages(req.body.threadId, req.user)
+const revealHiddenMessageModeMessages = catchAsync(async (req, res) => {
+  const thread = await threadService.revealHiddenMessageModeMessages(req.body.threadId, req.user)
   if (worker) {
     worker.send({
       thread: req.body.threadId,
@@ -81,5 +81,5 @@ module.exports = {
   follow,
   allPublic,
   deleteThread,
-  revealHitTheButtonHiddenMessages
+  revealHiddenMessageModeMessages
 }

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -155,7 +155,7 @@ components:
           type: boolean
         messageCount:
           type: number
-        hitTheButton:
+        hiddenMessageMode:
           type: boolean
       example:
         id: 61b0ffca7d4eb20ee9dcfe8c

--- a/src/models/message.model.js
+++ b/src/models/message.model.js
@@ -57,7 +57,7 @@ const messageSchema = mongoose.Schema(
       required: true,
       index: true
     },
-    hitTheButtonhidden: {
+    hiddenMessageModeHidden: {
       type: Boolean,
       default: false,
       required: true

--- a/src/models/thread.model.js
+++ b/src/models/thread.model.js
@@ -45,9 +45,9 @@ const threadSchema = mongoose.Schema(
     },
     followers: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Follower' }],
     agents: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Agent' }],
-    hitTheButton: {
+    hiddenMessageMode: {
       type: mongoose.SchemaTypes.Boolean,
-      ref: 'HitTheButton',
+      ref: 'HiddenMessageMode',
       default: false
     }
   },

--- a/src/routes/v1/threads.route.js
+++ b/src/routes/v1/threads.route.js
@@ -139,7 +139,7 @@ router.route('/').put(auth('updateThread'), validate(threadValidation.updateThre
  *               $ref: '#/components/schemas/Thread'
  *
  */
-router.route('/reveal').put(auth('revealHitTheButtonHiddenMessages'), threadsController.revealHitTheButtonHiddenMessages)
+router.route('/reveal').put(auth('revealHiddenMessageModeMessages'), threadsController.revealHiddenMessageModeMessages)
 
 /**
  * @swagger

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -65,7 +65,7 @@ const createMessage = async (messageBody, user, thread) => {
     owner: user,
     pseudonym: activePseudo.pseudonym,
     pseudonymId: activePseudo._id,
-    hitTheButtonhidden: thread.hitTheButton
+    hiddenMessageModeHidden: thread.hiddenMessageMode
   }
 
   if (messageBody.parentMessage) {
@@ -86,7 +86,7 @@ const threadMessages = async (id, userId) => {
     visible: true,
     parentMessage: { $exists: false }
   })
-    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt fromAgent hitTheButtonhidden')
+    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt fromAgent hiddenMessageModeHidden')
     .sort({ createdAt: 1 })
     .exec()
 
@@ -111,13 +111,13 @@ const threadMessages = async (id, userId) => {
     replyCountMap[item._id.toString()] = item.count
   })
 
-  // Redact body and pseudonym for hitTheButtonhidden messages not owned by the user
+  // Redact body and pseudonym for hiddenMessageModeHidden messages not owned by the user
   const redactedMessages = messages.map((msg) => {
     const msgObj = msg.toObject()
 
     msgObj.replyCount = replyCountMap[msg._id.toString()] || 0
 
-    if (msg.hitTheButtonhidden === true && msg.owner.toString() !== userId.toString()) {
+    if (msg.hiddenMessageModeHidden === true && msg.owner.toString() !== userId.toString()) {
       return {
         ...msgObj,
         body: null,
@@ -233,13 +233,13 @@ const getMessageReplies = async (messageId, userId) => {
     parentMessage: messageId,
     visible: true
   })
-    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt fromAgent hitTheButtonhidden')
+    .select('body owner upVotes downVotes pseudonym pseudonymId createdAt fromAgent hiddenMessageModeHidden')
     .sort({ createdAt: 1 })
     .exec()
 
-  // Redact body and pseudonym for hitTheButtonhidden messages not owned by the user
+  // Redact body and pseudonym for hiddenMessageModeHidden messages not owned by the user
   const redactedReplies = replies.map((msg) => {
-    if (msg.hitTheButtonhidden === true && msg.owner.toString() !== userId.toString()) {
+    if (msg.hiddenMessageModeHidden === true && msg.owner.toString() !== userId.toString()) {
       return {
         ...msg.toObject(),
         body: null,

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -4,7 +4,7 @@ const { Thread, Topic, Follower, Message } = require('../models')
 const updateDocument = require('../utils/updateDocument')
 const ApiError = require('../utils/ApiError')
 
-const returnFields = 'name slug locked owner createdAt messageCount hitTheButton'
+const returnFields = 'name slug locked owner createdAt messageCount hiddenMessageMode'
 
 /**
  * Create a thread
@@ -28,7 +28,7 @@ const createThread = async (threadBody, user) => {
     messageCount: 0,
     enableAgents: !!threadBody.agentTypes.length,
     agents: [],
-    hitTheButton: threadBody?.hitTheButton ? threadBody?.hitTheButton : false
+    hiddenMessageMode: threadBody?.hiddenMessageMode ? threadBody?.hiddenMessageMode : false
   })
 
   // need to save to get id
@@ -75,14 +75,14 @@ const updateThread = async (threadBody, user) => {
   return threadDoc
 }
 
-const revealHitTheButtonHiddenMessages = async (threadId, user) => {
+const revealHiddenMessageModeMessages = async (threadId, user) => {
   const thread = await Thread.findById(threadId)
   if (user._id.toString() !== thread.owner.toString() && user._id.toString() !== thread.topic.owner.toString()) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or topic owner can reveal hidden messages.')
   }
 
-  // Set hitTheButtonhidden=false for all messages in this thread
-  await Message.updateMany({ thread: threadId, hitTheButtonhidden: true }, { $set: { hitTheButtonhidden: false } })
+  // Set hiddenMessageModeHidden=false for all messages in this thread
+  await Message.updateMany({ thread: threadId, hiddenMessageModeHidden: true }, { $set: { hiddenMessageModeHidden: false } })
 
   return thread
 }
@@ -178,5 +178,5 @@ module.exports = {
   allPublic,
   deleteThread,
   updateThread,
-  revealHitTheButtonHiddenMessages
+  revealHiddenMessageModeMessages
 }

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -28,7 +28,7 @@ const createThread = async (threadBody, user) => {
     messageCount: 0,
     enableAgents: !!threadBody.agentTypes.length,
     agents: [],
-    hiddenMessageMode: threadBody?.hiddenMessageMode ? threadBody?.hiddenMessageMode : false
+    hitTheButton: threadBody?.hitTheButton ? threadBody?.hitTheButton : false
   })
 
   // need to save to get id
@@ -76,13 +76,15 @@ const updateThread = async (threadBody, user) => {
 }
 
 const revealHiddenMessageModeMessages = async (threadId, user) => {
-  const thread = await Thread.findById(threadId)
+  const thread = await Thread.findById(threadId).populate('topic')
   if (user._id.toString() !== thread.owner.toString() && user._id.toString() !== thread.topic.owner.toString()) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or topic owner can reveal hidden messages.')
   }
 
-  // Set hiddenMessageModeHidden=false for all messages in this thread
   await Message.updateMany({ thread: threadId, hiddenMessageModeHidden: true }, { $set: { hiddenMessageModeHidden: false } })
+
+  thread.hiddenMessageMode = false
+  await thread.save()
 
   return thread
 }

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -66,7 +66,7 @@ const createThread = async (threadBody, user) => {
 const updateThread = async (threadBody, user) => {
   let threadDoc = await Thread.findById(threadBody.id).populate('topic')
   if (user._id.toString() !== threadDoc.owner.toString() && user._id.toString() !== threadDoc.topic.owner.toString()) {
-    throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or topic owner can update.')
+    throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or channel owner can update.')
   }
 
   threadDoc = updateDocument(threadBody, threadDoc)
@@ -78,7 +78,7 @@ const updateThread = async (threadBody, user) => {
 const revealHiddenMessageModeMessages = async (threadId, user) => {
   const thread = await Thread.findById(threadId).populate('topic')
   if (user._id.toString() !== thread.owner.toString() && user._id.toString() !== thread.topic.owner.toString()) {
-    throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or topic owner can reveal hidden messages.')
+    throw new ApiError(httpStatus.FORBIDDEN, 'Only thread or channel owner can reveal hidden messages.')
   }
 
   await Message.updateMany({ thread: threadId, hiddenMessageModeHidden: true }, { $set: { hiddenMessageModeHidden: false } })

--- a/src/validations/thread.validation.js
+++ b/src/validations/thread.validation.js
@@ -5,7 +5,7 @@ const updateThread = {
     id: Joi.string().required(),
     name: Joi.string(),
     locked: Joi.boolean(),
-    hiddenMessageMode: Joi.boolean()
+    hiddenMessageMode: Joi.boolean().optional()
   })
 }
 

--- a/src/validations/thread.validation.js
+++ b/src/validations/thread.validation.js
@@ -5,7 +5,7 @@ const updateThread = {
     id: Joi.string().required(),
     name: Joi.string(),
     locked: Joi.boolean(),
-    hitTheButton: Joi.boolean()
+    hiddenMessageMode: Joi.boolean()
   })
 }
 

--- a/src/websockets/messageHandlers.js
+++ b/src/websockets/messageHandlers.js
@@ -1,4 +1,5 @@
 const { messageService } = require('../services')
+const { Thread } = require('../models')
 const catchAsync = require('../utils/catchAsync')
 const WebsocketError = require('../utils/WebsocketError')
 const { checkAuth } = require('./utils')
@@ -10,6 +11,12 @@ module.exports = (io, socket) => {
       logger.error('No request data.')
 
       return
+    }
+
+    // Store userId on the socket if not already stored
+    if (data.user && data.user._id && !socket.data?.userId) {
+      socket.data = socket.data || {}
+      socket.data.userId = data.user._id.toString()
     }
 
     try {
@@ -25,26 +32,61 @@ module.exports = (io, socket) => {
         )
 
         message.owner = data.user._id
-        if (message.hiddenMessageModeHidden) {
-          // Send redacted message to everyone else in the thread
-          const redactedMessage = {
+
+        if (message.hiddenMessageModeHidden === true) {
+          const thread = await Thread.findById(message.thread).populate('topic').exec()
+          const channelOwnerId = thread.topic?.owner?.toString()
+          const isMessageFromChannelOwner = data.user._id.toString() === channelOwnerId
+
+          // Prepare base message
+          const baseMessage = {
             ...message.toJSON(),
-            body: null,
-            pseudonym: null
+            threadMessageCount: message.threadMessageCount,
+            request: data.request
           }
-          socket.to(message.thread._id.toString()).emit('message:new', {
-            ...redactedMessage,
-            threadMessageCount: message.threadMessageCount,
-            request: data.request
-          })
-          // Send full message to the sender only
-          socket.emit('message:new', {
-            ...message.toJSON(),
-            threadMessageCount: message.threadMessageCount,
-            request: data.request
-          })
+
+          if (isMessageFromChannelOwner) {
+            // Channel owner's messages are visible to everyone
+            const messageWithLabel = {
+              ...baseMessage,
+              visibilityLabel: 'Message from facilitator, visible to everyone'
+            }
+            io.in(message.thread._id.toString()).emit('message:new', messageWithLabel)
+          } else {
+            // Non-channel owner's message - need to handle different recipients differently
+
+            // First, send full message to the sender themselves
+            const senderMessage = {
+              ...baseMessage,
+              visibilityLabel: 'Message is hidden from everyone except the facilitator'
+            }
+            socket.emit('message:new', senderMessage)
+
+            // Then handle all other sockets in the room
+            const socketsInRoom = await io.in(message.thread._id.toString()).fetchSockets()
+
+            for (const recipientSocket of socketsInRoom) {
+              // Skip the sender's socket (we already sent to them above)
+              if (recipientSocket.id === socket.id) continue
+
+              const recipientUserId = recipientSocket.data?.userId
+              const messageToSend = { ...baseMessage }
+
+              // Check if recipient is the channel owner
+              if (recipientUserId && recipientUserId === channelOwnerId) {
+                // Channel owner can see all messages
+                messageToSend.visibilityLabel = 'Message from participant, visible to you and author'
+              } else {
+                // Other participants and unauthenticated users can't see the message
+                messageToSend.body = null
+                messageToSend.hiddenForUser = true
+                messageToSend.visibilityLabel = 'Message hidden from everyone else except the facilitator.'
+              }
+
+              recipientSocket.emit('message:new', messageToSend)
+            }
+          }
         } else {
-          // Send full message to everyone in the thread
           io.in(message.thread._id.toString()).emit('message:new', {
             ...message.toJSON(),
             threadMessageCount: message.threadMessageCount,
@@ -67,6 +109,12 @@ module.exports = (io, socket) => {
   const joinThread = catchAsync(async (data) => {
     logger.debug('Joining thread via socket. ThreadId = %s', data.threadId)
     socket.join(data.threadId.toString())
+    // Store userId on socket for later use
+    if (data.user) {
+      socket.data = socket.data || {}
+      // Handle both user._id and user.id cases
+      socket.data.userId = (data.user._id || data.user.id || data.user).toString()
+    }
   })
 
   socket.use(([event, args], next) => {
@@ -93,6 +141,13 @@ module.exports = (io, socket) => {
 
   socket.on('message:create', createMessage)
   socket.on('thread:join', joinThread)
+  socket.on('user:join', (data) => {
+    if (data.userId) {
+      socket.data = socket.data || {}
+      socket.data.userId = data.userId
+      socket.join(data.userId)
+    }
+  })
   socket.on('thread:disconnect', () => {
     logger.info('Socket disconnecting from thread.')
     socket.disconnect(true)

--- a/src/websockets/messageHandlers.js
+++ b/src/websockets/messageHandlers.js
@@ -25,7 +25,7 @@ module.exports = (io, socket) => {
         )
 
         message.owner = data.user._id
-        if (message.hitTheButtonhidden) {
+        if (message.hiddenMessageModeHidden) {
           // Send redacted message to everyone else in the thread
           const redactedMessage = {
             ...message.toJSON(),


### PR DESCRIPTION
- Change hit the button to hidden message mode
- Change button to reveal hidden message
- Switch this feature from being a check box to being a button called “enter hidden message mode”
- Move the button to the middle of the chat window next to where new messages shows up
- Add hidden message count to the hidden message button
- Make the thread go back to normal mode when messages are revealed with the reveal button
- Add confirmation dialog to the reveal button
- Change so that channel owners
  - can see messages in hidden message mode
  - make owners’ messages visible to everyone
- Change so that either channel owner or thread owner can
  - Enter hidden message mode
  - trigger reveals
- Change to only redact message body text, and don't redact the pseudonym 
- Add notice that a given message is redacted for other participants to participants’ own messages
- Adjust the message notice to read
  - For participants: This thread is in hidden message mode. Your messages will be redacted until a facilitator reveals them.
  - For channel owner: This thread is in hidden message mode. Participants will not see each others’ messages until you reveal them.